### PR TITLE
Add Validation to Ensure poll_end is in the Future During Poll Initialization

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -13,7 +13,18 @@ pub mod voting {
                             description: String,
                             poll_start: u64,
                             poll_end: u64) -> Result<()> {
-
+        if !is_valid_unix_timestamp(poll_start) || !is_valid_unix_timestamp(poll_end) {
+            return err!(VotingError::InvalidTimestamp);
+        }
+        // Ensure poll_end is in the future
+        let current_time = Clock::get()?.unix_timestamp as u64;
+        if poll_end <= current_time {
+            return err!(VotingError::PollEndedInPast);
+        }
+        // Ensure poll_start is before poll_end
+        if poll_start >= poll_end {
+            return err!(VotingError::InvalidPollDuration);
+        }
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
         poll.description = description;
@@ -42,6 +53,20 @@ pub mod voting {
         Ok(())
     }
 
+}
+fn is_valid_unix_timestamp(timestamp: u64) -> bool {
+    let max_reasonable_timestamp = 1893456000; // Approximately 2029-30
+    timestamp > 0 && timestamp < max_reasonable_timestamp
+}
+
+#[error_code]
+pub enum VotingError {
+    #[msg("Invalid timestamp provided")]
+    InvalidTimestamp,
+    #[msg("Poll end time must be in the future")]
+    PollEndedInPast,
+    #[msg("Poll start time must be before end time")]
+    InvalidPollDuration,
 }
 
 #[derive(Accounts)]


### PR DESCRIPTION
Problem Statement:
Currently, there is no validation to ensure that poll_end is set in the future. This could lead to cases where a poll is initialized with an already expired end time, making it invalid. Additionally, there is no validation to check if the provided value is a valid Unix timestamp.

Solution:
Added a validation check to ensure poll_end is greater than the current time during poll initialization.
Implemented an additional check to verify that the input is a valid Unix timestamp.
Bounty:
💰 $10

Submission Instructions:
Please review the changes, and ensure the logic correctly prevents invalid timestamps.

Note: My registered email address for the Solana Devs India Tour Workshop is 2005akjha@gmail.com 
