### PR TITLE
added count votes functionality for all candidates

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -1,22 +1,29 @@
 #![allow(clippy::result_large_err)]
 
 use anchor_lang::prelude::*;
-//changes #1
+
 #[error_code]
 pub enum VotingError {
     #[msg("The poll has not started yet")]
     PollNotStarted,
     #[msg("The poll has already ended")]
     PollEnded,
+    #[msg("Invalid timestamp provided")]
+    InvalidTimestamp,
+    #[msg("Poll end time must be in the future")]
+    PollEndedInPast,
+    #[msg("Poll start time must be before end time")]
+    InvalidPollDuration,
+    #[msg("This address has already voted for this poll")]
+    AlreadyVoted,
 }
-//end 
+
 declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
 
 #[program]
 pub mod voting {
     use super::*;
 
-    // Initializes a poll
     pub fn initialize_poll(ctx: Context<InitializePoll>, 
                             poll_id: u64,
                             description: String,
@@ -25,12 +32,10 @@ pub mod voting {
         if !is_valid_unix_timestamp(poll_start) || !is_valid_unix_timestamp(poll_end) {
             return err!(VotingError::InvalidTimestamp);
         }
-        // Ensure poll_end is in the future
         let current_time = Clock::get()?.unix_timestamp as u64;
         if poll_end <= current_time {
             return err!(VotingError::PollEndedInPast);
         }
-        // Ensure poll_start is before poll_end
         if poll_start >= poll_end {
             return err!(VotingError::InvalidPollDuration);
         }
@@ -40,10 +45,10 @@ pub mod voting {
         poll.poll_start = poll_start;
         poll.poll_end = poll_end;
         poll.candidate_amount = 0;
+        poll.total_votes = 0;
         Ok(())
     }
 
-    // Initializes a candidate for a given poll
     pub fn initialize_candidate(ctx: Context<InitializeCandidate>, 
                                 candidate_name: String,
                                 _poll_id: u64
@@ -53,20 +58,15 @@ pub mod voting {
         candidate.candidate_votes = 0;
 
         let poll = &mut ctx.accounts.poll;
-        poll.candidate_amount += 1; // Increment the candidate count
-
+        poll.candidate_amount += 1;
         Ok(())
     }
 
-    // Allows a signer to vote for a candidate, ensuring they can only vote once
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
-        // Check if the signer has already voted for this poll
         if ctx.accounts.voter_record.voted {
-            return Err(error!(VotingError::AlreadyVoted)); // Return an error if they have already voted
+            return Err(error!(VotingError::AlreadyVoted));
         }
-
-        //changes 2
-        let poll = &ctx.accounts.poll;
+        let poll = &mut ctx.accounts.poll;
         let current_time = Clock::get()?.unix_timestamp as u64;
         
         require!(
@@ -78,43 +78,36 @@ pub mod voting {
             current_time <= poll.poll_end,
             VotingError::PollEnded
         );
-        //end of change
+        
         let candidate = &mut ctx.accounts.candidate;
-        candidate.candidate_votes += 1; // Increment the vote for the selected candidate
-
-        // Record that the signer has voted
+        candidate.candidate_votes += 1;
+        poll.total_votes += 1;
+        
         let voter_record = &mut ctx.accounts.voter_record;
         voter_record.voted = true;
         voter_record.poll = ctx.accounts.poll.key();
 
-        msg!("Voted for candidate: {}", candidate.candidate_name); // Log the vote
-        msg!("Votes: {}", candidate.candidate_votes); // Log the updated vote count
+        msg!("Voted for candidate: {}", candidate.candidate_name);
+        msg!("Candidate Votes: {}", candidate.candidate_votes);
+        msg!("Total Votes in Poll: {}", poll.total_votes);
         Ok(())
     }
 }
-fn is_valid_unix_timestamp(timestamp: u64) -> bool {
-    let max_reasonable_timestamp = 1893456000; // Approximately 2029-30
-    timestamp > 0 && timestamp < max_reasonable_timestamp
-}
 
-#[error_code]
-pub enum VotingError {
-    #[msg("Invalid timestamp provided")]
-    InvalidTimestamp,
-    #[msg("Poll end time must be in the future")]
-    PollEndedInPast,
-    #[msg("Poll start time must be before end time")]
-    InvalidPollDuration,
+fn is_valid_unix_timestamp(timestamp: u64) -> bool {
+    let max_reasonable_timestamp = 1893456000;
+    timestamp > 0 && timestamp < max_reasonable_timestamp
 }
 
 #[derive(Accounts)]
 #[instruction(candidate_name: String, poll_id: u64)]
 pub struct Vote<'info> {
     #[account(mut)]
-    pub signer: Signer<'info>, // The signer (voter) account
+    pub signer: Signer<'info>,
 
     #[account(
-        seeds = [poll_id.to_le_bytes().as_ref()], // Unique seeds for poll account
+        mut,
+        seeds = [poll_id.to_le_bytes().as_ref()],
         bump
     )]
     pub poll: Account<'info, Poll>,
@@ -126,12 +119,11 @@ pub struct Vote<'info> {
     )]
     pub candidate: Account<'info, Candidate>,
 
-    // Voter record is created if it doesn't exist; ensures only one vote per user per poll
     #[account(
       init_if_needed,
       payer = signer,
-      space = 8 + VoterRecord::INIT_SPACE, // Space allocation for VoterRecord
-      seeds = [signer.key().as_ref(), poll_id.to_le_bytes().as_ref()], // Unique seeds for voter record
+      space = 8 + VoterRecord::INIT_SPACE,
+      seeds = [signer.key().as_ref(), poll_id.to_le_bytes().as_ref()],
       bump
     )]
     pub voter_record: Account<'info, VoterRecord>,
@@ -168,7 +160,7 @@ pub struct InitializeCandidate<'info> {
 pub struct Candidate {
     #[max_len(32)]
     pub candidate_name: String,
-    pub candidate_votes: u64, // Vote count for this candidate
+    pub candidate_votes: u64,
 }
 
 #[derive(Accounts)]
@@ -192,17 +184,18 @@ pub struct InitializePoll<'info> {
 pub struct Poll {
     pub poll_id: u64,
     #[max_len(200)]
-    pub description: String, // Description of the poll
-    pub poll_start: u64, // Poll start timestamp
-    pub poll_end: u64, // Poll end timestamp
-    pub candidate_amount: u64, // Number of candidates in the poll
+    pub description: String,
+    pub poll_start: u64,
+    pub poll_end: u64,
+    pub candidate_amount: u64,
+    pub total_votes: u64,
 }
 
 #[account]
 #[derive(InitSpace)]
 pub struct VoterRecord {
-    pub voted: bool, // Flag to track if the voter has voted
-    pub poll: Pubkey, // The poll the voter has voted in
+    pub voted: bool,
+    pub poll: Pubkey,
 }
 
 #[error_code]


### PR DESCRIPTION
Previously, 
There was no way to track the total number of votes cast in a poll, even though each candidate's votes were counted individually. To fix this, I added a `total_votes` field to the Poll struct, initialized it in `initialize_poll`, and incremented it in the `vote` function.

This ensures that every vote updates both:

- The individual candidate's vote count - `candidate_votes`.
- The total number of votes in the poll - `total_votes`.

Now, it's easier to see the overall voting activity in a poll without manually summing up individual candidate votes.

I used the registered email address - gupta878aditya@gmail.com to attend the Lucknow Solana Devs India Tour Workshop!

This PR is an attempt to solve bounty #2. 
 This pull request was created for https://app.gib.work/bounties/51bac8af-2b9e-40e1-9f45-5530536647d2 in an attempt to solve a bounty #2 . Payment for the bounty is immediately sent to the contributor after merge.